### PR TITLE
✨ Remove redirection to help debug

### DIFF
--- a/.github/workflows/builder.yml
+++ b/.github/workflows/builder.yml
@@ -245,7 +245,7 @@ jobs:
           # to compute the actual directory.
           echo "./$BUILDER_BINARY" build "$CONFIG_FILE" "$UNTRUSTED_ENVS"
           export OUTPUT_BINARY="${{ env.GENERATED_BINARY_NAME }}"
-          ./"$BUILDER_BINARY" build "$CONFIG_FILE" "$UNTRUSTED_ENVS" &>/dev/null
+          ./"$BUILDER_BINARY" build "$CONFIG_FILE" "$UNTRUSTED_ENVS"
 
 
       - name: Compute binary hash


### PR DESCRIPTION
We initially redirected stdin/stderr to avoid the compiler from printing commands via `::set-output`. This is no longer needed since we're doing the print in the next step, which would overwrite previous commands.

closes https://github.com/gossts/slsa-go/issues/4