### PR TITLE
✨ Lower case sha field

### DIFF
--- a/pkg/provenance.go
+++ b/pkg/provenance.go
@@ -136,7 +136,7 @@ func GenerateProvenance(name, digest, ghContext, command string) ([]byte, error)
 					EntryPoint: gh.Workflow,
 					URI:        fmt.Sprintf("git+%s%s@%s.git", gh.ServerUrl, gh.Repository, gh.Ref),
 					Digest: slsa.DigestSet{
-						"SHA1": gh.SHA,
+						"sha1": gh.SHA,
 					},
 				},
 				// Non user-controllable environment vars needed to reproduce the build.
@@ -175,7 +175,7 @@ func GenerateProvenance(name, digest, ghContext, command string) ([]byte, error)
 				{
 					URI: fmt.Sprintf("git+%s.git", gh.Repository),
 					Digest: slsa.DigestSet{
-						"SHA1": gh.SHA,
+						"sha1": gh.SHA,
 					},
 				},
 			},


### PR DESCRIPTION
All fields are lowercase, so let's make `sha` fields lower case too.
Or is there a reason (specs?) to keep them upper case?